### PR TITLE
Fix calculate_weight received unrecognized argument intermediate_dtype

### DIFF
--- a/utils/patches.py
+++ b/utils/patches.py
@@ -11,8 +11,8 @@ def calculate_weight_adjust_channel(func):
     """Patches ComfyUI's LoRA weight application to accept multi-channel inputs."""
 
     @functools.wraps(func)
-    def calculate_weight(patches, weight: torch.Tensor, key: str) -> torch.Tensor:
-        weight = func(patches, weight, key)
+    def calculate_weight(patches, weight: torch.Tensor, key: str, intermediate_dtype=torch.float32) -> torch.Tensor:
+        weight = func(patches, weight, key, intermediate_dtype)
 
         for p in patches:
             alpha = p[0]


### PR DESCRIPTION
The calculate_weight_adjust_channel breaks compatibility with comfy lora: https://github.com/comfyanonymous/ComfyUI/blob/669d9e4c67849e380044871788eb2be615a50396/comfy/lora.py#L403

This patch fixes it.